### PR TITLE
Rename groupfolder names to match real directorys

### DIFF
--- a/samba/smbFolders
+++ b/samba/smbFolders
@@ -1,27 +1,27 @@
 
-[SchulTausch]
+[schoolExchange]
     path = /home/schoolExchange
     writeable = yes
 
-[RaumTausch]
+[roomExchange]
     path = /home/roomExchange
     writeable = yes
 
-[SchulVorlagenSchueler]
+[schoolTemplate]
     path = /home/schoolTemplate
     writeable = no
 
-[SchulVorlagenLehrer]
+[schoolTemplateTeachers]
     path = /home/schoolTemplate
     valid users = @teachers
     writable = yes
 
-[LehrerTausch]
+[teacherExchange]
     path = /home/teacherExchange
     writable = yes
     valid users = @teachers
 
-[LehrerVorlagen]
+[teacherTemplate]
     path = /home/teacherTemplate
     writable = no
     valid users = @teachers


### PR DESCRIPTION
It's better to use the names of the directors, because in the backend every directory is shown as an option to use.